### PR TITLE
Add assertions

### DIFF
--- a/src/main/java/asura/parser/Parser.java
+++ b/src/main/java/asura/parser/Parser.java
@@ -23,6 +23,7 @@ public class Parser {
      */
     public static Command parse(String command) throws AsuraException {
         List<String> splitCommand = Arrays.asList(command.split(" "));
+        assert !splitCommand.isEmpty() : "splitCommand should not be empty";
         String prefix = splitCommand.get(0);
         if (splitCommand.size() == 1 && !Objects.equals(prefix, "list") && !Objects.equals(prefix, "bye")) {
             throw new AsuraException("Invalid command format");

--- a/src/main/java/asura/ui/Ui.java
+++ b/src/main/java/asura/ui/Ui.java
@@ -147,7 +147,9 @@ public class Ui extends Application {
      */
     private void handleUserInput() {
         String userText = userInput.getText();
+        assert userText != null : "User input should not be null";
         String asuraText = asura.getResponse(userInput.getText());
+        assert asuraText != null : "Asura text should not be null";
         dialogContainer.getChildren().addAll(
                 DialogBox.getUserDialog(userText, userImage),
                 DialogBox.getDukeDialog(asuraText, asuraImage)


### PR DESCRIPTION
The current codebase does not currently check for non-empty data and command elements, which can lead to unexpected errors or behavior when processing input.

This needs to change to ensure that key assumptions hold true and to make the code easier to debug

Add assertions to validate that variables such as splitCommand are not empty. These assertions ensure that the program behaves as expected and catches potential errors.

Assertions are used to verify assumptions during the runtime of the program.